### PR TITLE
Move RGBMatrix to Protomatter, misc. tweaks

### DIFF
--- a/Firmware/Arduino/AdafruitRGBMatrix_EPXDriver.cpp
+++ b/Firmware/Arduino/AdafruitRGBMatrix_EPXDriver.cpp
@@ -5,13 +5,83 @@
 
 EPX_OPTIMIZEFORDEBUGGING_ON
 
-CAdafruitRGBMatrix_EPXDriver::CAdafruitRGBMatrix_EPXDriver(int width, int height, uint8_t pinCLK, uint8_t pinOE, uint8_t pinLAT, uint8_t pinA, uint8_t pinB, uint8_t pinC, uint8_t pinD, uint8_t *prgbpins)
+/* ----------------------------------------------------------------------
+The RGB matrix must be wired to VERY SPECIFIC pins, different for each
+microcontroller board. This first section sets that up for a number of
+supported boards.
+------------------------------------------------------------------------- */
+#if defined(_VARIANT_MATRIXPORTAL_M4_) // MatrixPortal M4
+	uint8_t rgbPins[]  = {7, 8, 9, 10, 11, 12};
+	uint8_t addrPins[] = {17, 18, 19, 20};
+	uint8_t clockPin   = 14;
+	uint8_t latchPin   = 15;
+	uint8_t oePin      = 16;
+#elif defined(_VARIANT_FEATHER_M4_) // Feather M4 + RGB Matrix FeatherWing
+	uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+	uint8_t addrPins[] = {A5, A4, A3, A2};
+	uint8_t clockPin   = 13;
+	uint8_t latchPin   = 0;
+	uint8_t oePin      = 1;
+#elif defined(__SAMD51__) // M4 Metro Variants (Express, AirLift)
+	uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+	uint8_t addrPins[] = {A5, A4, A3, A2};
+	uint8_t clockPin   = 13;
+	uint8_t latchPin   = 0;
+	uint8_t oePin      = 1;
+#elif defined(_SAMD21_) // Feather M0 variants
+	uint8_t rgbPins[]  = {6, 7, 10, 11, 12, 13};
+	uint8_t addrPins[] = {0, 1, 2, 3};
+	uint8_t clockPin   = SDA;
+	uint8_t latchPin   = 4;
+	uint8_t oePin      = 5;
+#elif defined(NRF52_SERIES) // Special nRF52840 FeatherWing pinout
+	uint8_t rgbPins[]  = {6, A5, A1, A0, A4, 11};
+	uint8_t addrPins[] = {10, 5, 13, 9};
+	uint8_t clockPin   = 12;
+	uint8_t latchPin   = PIN_SERIAL1_RX;
+	uint8_t oePin      = PIN_SERIAL1_TX;
+#elif defined(ESP32)
+  // 'Safe' pins, not overlapping any peripherals:
+  // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33
+  // Peripheral-overlapping pins, sorted from 'most expendible':
+  // 16, 17 (RX, TX)
+  // 25, 26 (A0, A1)
+  // 18, 5, 9 (MOSI, SCK, MISO)
+  // 22, 23 (SCL, SDA)
+  uint8_t rgbPins[]  = {4, 12, 13, 14, 15, 21};
+  uint8_t addrPins[] = {16, 17, 25, 26};
+  uint8_t clockPin   = 27; // Must be on same port as rgbPins
+  uint8_t latchPin   = 32;
+  uint8_t oePin      = 33;
+#elif defined(ARDUINO_TEENSY40)
+  uint8_t rgbPins[]  = {15, 16, 17, 20, 21, 22}; // A1-A3, A6-A8, skip SDA,SCL
+  uint8_t addrPins[] = {2, 3, 4, 5};
+  uint8_t clockPin   = 23; // A9
+  uint8_t latchPin   = 6;
+  uint8_t oePin      = 9;
+#elif defined(ARDUINO_TEENSY41)
+  uint8_t rgbPins[]  = {26, 27, 38, 20, 21, 22}; // A12-14, A6-A8
+  uint8_t addrPins[] = {2, 3, 4, 5};
+  uint8_t clockPin   = 23; // A9
+  uint8_t latchPin   = 6;
+  uint8_t oePin      = 9;
+#endif
+
+
+CAdafruitRGBMatrix_EPXDriver::CAdafruitRGBMatrix_EPXDriver(int width, int height)
 	: CLEDDriverBase(width * height)
 {
 	m_width = width;
 	m_height = height;
 	m_nRainbowIteration = 0;
-	m_pRGBmatrixPanel = new RGBmatrixPanel(pinA, pinB, pinC, pinD, pinCLK, pinOE, pinLAT, false, width, prgbpins);
+	brightness = 255;
+	m_pRGBmatrixPanel = new Adafruit_Protomatter(
+		64,							// Width of matrix (or matrix chain) in pixels
+		4,							// Bit depth, 1-6
+		1, rgbPins,					// # of matrix chains, array of 6 RGB pins for each
+		4, addrPins,				// # of address pins (height is inferred), array of pins
+		clockPin, latchPin, oePin,	// Other matrix control pins
+		true);						// Allow double-buffering
 }
 
 
@@ -28,14 +98,23 @@ CAdafruitRGBMatrix_EPXDriver::~CAdafruitRGBMatrix_EPXDriver()
 
 void CAdafruitRGBMatrix_EPXDriver::Initialize()
 {
-	m_pRGBmatrixPanel->begin();
+	ProtomatterStatus status = m_pRGBmatrixPanel->begin();
+	Serial.print("Protomatter begin() status: ");
+	Serial.println((int)status);
+	if(status != PROTOMATTER_OK) {
+		// DO NOT CONTINUE if matrix setup encountered an error.
+		for(;;);
+	}
 }
 
 
 
 void CAdafruitRGBMatrix_EPXDriver::SetBrightness(uint8_t brightness)
 {
-	
+	// This is not a protomatter function, mocked implementation.
+	if (b  != brightness) {
+		brightness = b;
+	}
 }
 
 
@@ -60,21 +139,21 @@ void CAdafruitRGBMatrix_EPXDriver::SetPixel(uint16_t idx, uint8_t r, uint8_t g, 
 
 void CAdafruitRGBMatrix_EPXDriver::SetPixelColor(uint16_t idx, uint32_t color)
 {
-	SetPixel(idx, (uint8_t)(color >> 16), (uint8_t)(color >>  8), (uint8_t) color);	
+	SetPixel(idx, (uint8_t)(color >> 16), (uint8_t)(color >>  8), (uint8_t) color);
 }
 
 
 
 void CAdafruitRGBMatrix_EPXDriver::Clear()
 {
-	
+	m_pRGBmatrixPanel->fillScreen(0);
 }
 
 
 
 void CAdafruitRGBMatrix_EPXDriver::Show()
 {
-	
+	m_pRGBmatrixPanel->show();
 }
 
 
@@ -103,6 +182,7 @@ void CAdafruitRGBMatrix_EPXDriver::Rainbow(uint8_t wait)
 	{
 		for (i = 0; i < m_numPixels; i++) 			
 			SetPixelColor(i, Wheel((i + j) & 255));
+		Show();
 		delay(wait);
 	}	
 }
@@ -121,6 +201,7 @@ void CAdafruitRGBMatrix_EPXDriver::RainbowCycle(uint8_t wait)
 	for(i = 0 ; i < m_numPixels; i++) 
 		//SetPixelColor(i, Wheel(((i * 256 / m_numPixels) + j) & 255));
 		SetPixelColor(i, Wheel((i + m_nRainbowIteration) & 255));	
+	Show();
 	delay(wait);
 
 	m_nRainbowIteration++;

--- a/Firmware/Arduino/AdafruitRGBMatrix_EPXDriver.cpp
+++ b/Firmware/Arduino/AdafruitRGBMatrix_EPXDriver.cpp
@@ -76,7 +76,7 @@ CAdafruitRGBMatrix_EPXDriver::CAdafruitRGBMatrix_EPXDriver(int width, int height
 	m_nRainbowIteration = 0;
 	brightness = 255;
 	m_pRGBmatrixPanel = new Adafruit_Protomatter(
-		64,							// Width of matrix (or matrix chain) in pixels
+		m_width,					// Width of matrix (or matrix chain) in pixels
 		4,							// Bit depth, 1-6
 		1, rgbPins,					// # of matrix chains, array of 6 RGB pins for each
 		4, addrPins,				// # of address pins (height is inferred), array of pins

--- a/Firmware/Arduino/AdafruitRGBMatrix_EPXDriver.h
+++ b/Firmware/Arduino/AdafruitRGBMatrix_EPXDriver.h
@@ -30,10 +30,11 @@ public:
 private:
 	uint32_t Wheel(uint8_t WheelPos);
 	
-	RGBmatrixPanel			*m_pRGBmatrixPanel;
-	uint32_t				*m_pTXBuffer;
-	uint32_t				m_nRainbowIteration;
-	int 					m_width; 
-	int 					m_height;
+	Adafruit_Protomatter				*m_pRGBmatrixPanel;
+	uint32_t							*m_pTXBuffer;
+	uint32_t							m_nRainbowIteration;
+	int 								m_width; 
+	int 								m_height;
+	int 								brightness;
 };
 

--- a/Firmware/Arduino/AdafruitRGBMatrix_EPXDriver.h
+++ b/Firmware/Arduino/AdafruitRGBMatrix_EPXDriver.h
@@ -13,7 +13,7 @@ class CAdafruitRGBMatrix_EPXDriver : public CLEDDriverBase
 {
 	
 public:
-	CAdafruitRGBMatrix_EPXDriver(int width, int height, uint8_t pinClk, uint8_t pinOE, uint8_t pinLAT, uint8_t pinA, uint8_t pinB, uint8_t pinC, uint8_t pinD, uint8_t *prgbpins);	
+	CAdafruitRGBMatrix_EPXDriver(int width, int height);	
 	~CAdafruitRGBMatrix_EPXDriver();
 	
 	void Initialize();

--- a/Firmware/Arduino/Examples/ExpressivePixelsMinimal/ExpressivePixels.ino
+++ b/Firmware/Arduino/Examples/ExpressivePixelsMinimal/ExpressivePixels.ino
@@ -4,91 +4,15 @@
 #include <CDisplayTopology.h>
 #include <CLEDDriverBase.h>
 
-// #ifdef ADAFRUIT_DOTSTAR
-#define ADAFRUIT_RGBMATRIX
-#define DISPLAY_ADARGBMATRIX64x32
-
-
-#ifdef ADAFRUIT_DOTSTAR
-#include <AdafruitDotStar_EPXDriver.h>
-#elif defined (ADAFRUIT_RGBMATRIX)
-#include <AdafruitRGBMatrix_EPXDriver.h>
-#else
-#include <AdafruitNeoPixel_EPXDriver.h>
-#endif
-
-extern uint8_t bootAnimation[];
-
-// Specify the data pin the LED array is connected to 
-#define PIN_STRIP            PIN_A2
-
-#ifdef DISPLAY_FEATHERWINGDOTSTAR
-// Specify dimensions of display connect to the device
-#define DISPLAYARRAY_WIDTH		16
-#define DISPLAYARRAY_HEIGHT		16
-
-// Specify the LED topology on the display
-uint16_t g_displayArrayPixelTopology[DISPLAYARRAY_WIDTH * DISPLAYARRAY_HEIGHT] = 
-{ 
-	60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 
-    48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-    36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
-    24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
-    12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-    0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
-};
-#elif defined (DISPLAY_FLEX16X16)
-// Specify dimensions of display connect to the device
-#define DISPLAYARRAY_WIDTH		16
-#define DISPLAYARRAY_HEIGHT		16
-
-uint16_t g_displayArrayPixelTopology[DISPLAYARRAY_WIDTH * DISPLAYARRAY_HEIGHT] = 
-{ 
-	0,  31, 32, 63, 64, 95, 96, 127,128,159,160,191,192,223,224,255,
-	1,  30, 33, 62, 65, 94, 97, 126,129,158,161,190,193,222,225,254,
-	2,  29, 34, 61, 66, 93, 98, 125,130,157,162,189,194,221,226,253,
-	3,  28, 35, 60, 67, 92, 99, 124,131,156,163,188,195,220,227,252,
-	4,  27, 36, 59, 68, 91,100, 123,132,155,164,187,196,219,228,251,
-	5,  26, 37, 58, 69, 90,101, 122,133,154,165,186,197,218,229,250,
-	6,  25, 38, 57, 70, 89,102, 121,134,153,166,185,198,217,230,249,
-	7,  24, 39, 56, 71, 88,103, 120,135,152,167,184,199,216,231,248,
-	8,  23, 40, 55, 72, 87,104, 119,136,151,168,183,200,215,232,247,
-	9,  22, 41, 54, 73, 86,105, 118,137,150,169,182,201,214,233,246,
-	10, 21, 42, 53, 74, 85,106, 117,138,149,170,181,202,213,234,245,
-	11, 20, 43, 52, 75, 84,107, 116,139,148,171,180,203,212,235,244,
-	12, 19, 44, 51, 76, 83,108, 115,140,147,172,179,204,211,236,243,
-	13, 18, 45, 50, 77, 82,109, 114,141,146,173,178,205,210,237,242,
-	14, 17, 46, 51, 78, 81,110, 113,142,145,174,177,206,209,238,241,
-	15, 16, 47, 48, 79, 80,111, 112,143,144,175,176,207,208,239,240
-};
-#elif defined (DISPLAY_SPARKLETSQUARE16X16)
-// Specify dimensions of display connect to the device
-#define DISPLAYARRAY_WIDTH		16
-#define DISPLAYARRAY_HEIGHT		16
-
-uint16_t g_displayArrayPixelTopology[DISPLAYARRAY_WIDTH * DISPLAYARRAY_HEIGHT];
-#elif defined (DISPLAY_ADARGBMATRIX64x32)
-#define CLK  13
-#define OE   1  // TX
-#define LAT  0  // RX
-#define A   A5
-#define B   A4
-#define C   A3
-#define D   A2
-uint8_t rgbpins[] = { 6,5,9,11,10,12 };
-
-#define DISPLAYARRAY_WIDTH		64
-#define DISPLAYARRAY_HEIGHT		32
-
-uint16_t g_displayArrayPixelTopology[DISPLAYARRAY_WIDTH * DISPLAYARRAY_HEIGHT];
-#endif
-
-
+/*************** Configuration ***************/
+// If you need to edit display size or pinout,
+// edit the `config.h` file in this directory.
+#include "config.h"
 
 /**** Classes to support animation ****/
-CDisplayArray		g_CDisplayArray;                // Display class
-CDisplayTopology	g_CDisplayTopology;             // Topology mapping class
-CAnimationManager	g_CAnimator(&g_CDisplayArray);  // Animator class
+CDisplayArray   g_CDisplayArray;                // Display class
+CDisplayTopology  g_CDisplayTopology;             // Topology mapping class
+CAnimationManager g_CAnimator(&g_CDisplayArray);  // Animator class
 
 
 
@@ -109,7 +33,7 @@ void setup()
     CAdafruitDotStar_EPXDriver *pDotStarDriver = new CAdafruitDotStar_EPXDriver(PIN_A2, PIN_A1, DISPLAYARRAY_WIDTH * DISPLAYARRAY_HEIGHT);
 #elif defined (ADAFRUIT_RGBMATRIX)
     // For Adafruit RGBMatrix displays
-    CAdafruitRGBMatrix_EPXDriver *pRGBMatrixDriver = new CAdafruitRGBMatrix_EPXDriver(DISPLAYARRAY_WIDTH, DISPLAYARRAY_HEIGHT, CLK, OE, LAT, A, B, C, D, rgbpins);
+    CAdafruitRGBMatrix_EPXDriver *pRGBMatrixDriver = new CAdafruitRGBMatrix_EPXDriver(DISPLAYARRAY_WIDTH, DISPLAYARRAY_HEIGHT);
 #else
     // For WS2812 LEDs
     CAdafruitNeoPixel_EPXDriver *pNeoPixel_EPXDriver = new CAdafruitNeoPixel_EPXDriver(PIN_STRIP, DISPLAYARRAY_WIDTH * DISPLAYARRAY_HEIGHT);

--- a/Firmware/Arduino/Examples/ExpressivePixelsMinimal/config.h
+++ b/Firmware/Arduino/Examples/ExpressivePixelsMinimal/config.h
@@ -1,0 +1,81 @@
+
+// Uncomment the following line(s) if you're using a LED RGB Matrix
+#define ADAFRUIT_RGBMATRIX
+#define DISPLAY_ADARGBMATRIX64x32
+
+// Uncomment the following lines if you're using NeoPixels
+// #define ADAFRUIT_NEOPIXEL
+// Specify the data pin the LED array is connected to 
+// #define PIN_STRIP            PIN_A2
+
+// Uncomment the following line if you're using Dotstar
+// #ifdef ADAFRUIT_DOTSTAR
+
+// Uncomment the following line if you're using the sparklet square
+#define DISPLAY_SPARKLETSQUARE16X16
+
+
+#ifdef ADAFRUIT_DOTSTAR
+    #include <AdafruitDotStar_EPXDriver.h>
+#elif defined (ADAFRUIT_RGBMATRIX)
+    #include <AdafruitRGBMatrix_EPXDriver.h>
+#elif defined (ADAFRUIT_NEOPIXEL)
+    #include <AdafruitNeoPixel_EPXDriver.h>
+#endif
+
+
+extern uint8_t bootAnimation[];
+
+
+
+#ifdef DISPLAY_FEATHERWINGDOTSTAR
+    // Specify dimensions of display connect to the device
+    #define DISPLAYARRAY_WIDTH		16
+    #define DISPLAYARRAY_HEIGHT		16
+
+    // Specify the LED topology on the display
+    uint16_t g_displayArrayPixelTopology[DISPLAYARRAY_WIDTH * DISPLAYARRAY_HEIGHT] = 
+    { 
+        60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 
+        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+        36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+        24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+        12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+        0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+    };
+#elif defined (DISPLAY_FLEX16X16)
+    // Specify dimensions of display connect to the device
+    #define DISPLAYARRAY_WIDTH		16
+    #define DISPLAYARRAY_HEIGHT		16
+
+    uint16_t g_displayArrayPixelTopology[DISPLAYARRAY_WIDTH * DISPLAYARRAY_HEIGHT] = 
+    { 
+        0,  31, 32, 63, 64, 95, 96, 127,128,159,160,191,192,223,224,255,
+        1,  30, 33, 62, 65, 94, 97, 126,129,158,161,190,193,222,225,254,
+        2,  29, 34, 61, 66, 93, 98, 125,130,157,162,189,194,221,226,253,
+        3,  28, 35, 60, 67, 92, 99, 124,131,156,163,188,195,220,227,252,
+        4,  27, 36, 59, 68, 91,100, 123,132,155,164,187,196,219,228,251,
+        5,  26, 37, 58, 69, 90,101, 122,133,154,165,186,197,218,229,250,
+        6,  25, 38, 57, 70, 89,102, 121,134,153,166,185,198,217,230,249,
+        7,  24, 39, 56, 71, 88,103, 120,135,152,167,184,199,216,231,248,
+        8,  23, 40, 55, 72, 87,104, 119,136,151,168,183,200,215,232,247,
+        9,  22, 41, 54, 73, 86,105, 118,137,150,169,182,201,214,233,246,
+        10, 21, 42, 53, 74, 85,106, 117,138,149,170,181,202,213,234,245,
+        11, 20, 43, 52, 75, 84,107, 116,139,148,171,180,203,212,235,244,
+        12, 19, 44, 51, 76, 83,108, 115,140,147,172,179,204,211,236,243,
+        13, 18, 45, 50, 77, 82,109, 114,141,146,173,178,205,210,237,242,
+        14, 17, 46, 51, 78, 81,110, 113,142,145,174,177,206,209,238,241,
+        15, 16, 47, 48, 79, 80,111, 112,143,144,175,176,207,208,239,240
+    };
+#elif defined (DISPLAY_SPARKLETSQUARE16X16)
+    // Specify dimensions of display connect to the device
+    #define DISPLAYARRAY_WIDTH		16
+    #define DISPLAYARRAY_HEIGHT		16
+
+    uint16_t g_displayArrayPixelTopology[DISPLAYARRAY_WIDTH * DISPLAYARRAY_HEIGHT];
+#elif defined (DISPLAY_ADARGBMATRIX64x32)
+    #define DISPLAYARRAY_WIDTH		64
+    #define DISPLAYARRAY_HEIGHT		32
+
+    uint16_t g_displayArrayPixelTopology[DISPLAYARRAY_WIDTH * DISPLAYARRAY_HEIGHT];
+#endif


### PR DESCRIPTION
* Moved RGBMatrix driver from RGBMatrix to the newer [Protomatter](https://github.com/adafruit/Adafruit_Protomatter) driver for 32-bit MCUs to support newer hardware. 
* RGBMatrix driver now selects the pins for each platform at compile time.
* Added `Clear`, `Show`, methods to RGBMatrix
* Brightness added to RGBMatrix, not implemented
* ExpressivePixels arduino example modified 
  * New `config.h` file for a user to configure their display, separate from the main sketch
  * Added `#defines`, updated code for readability